### PR TITLE
Fix "Quantified nested groups do not work"

### DIFF
--- a/lib/hafriedlander/Peg/Compiler/Token.php
+++ b/lib/hafriedlander/Peg/Compiler/Token.php
@@ -132,7 +132,7 @@ abstract class Token extends PHPWriter {
 	{
 		$counterName = '$count' . $id;
 		return PHPBuilder::build()->l(
-            $counterName . ' = 0;'
+			$counterName . ' = 0;'
 		)->b(
 			'while (\true)',
 			$this->save($id),
@@ -140,7 +140,7 @@ abstract class Token extends PHPWriter {
 				'MATCH' => \null,
 				'FAIL' => $this->restore($id, \true)->l('break;')
 			)),
-            $counterName . '++;'
+			$counterName . '++;'
 		)->b(
 			'if (' . $counterName . ' >= '.$n.')',
 			'MATCH'
@@ -154,9 +154,9 @@ abstract class Token extends PHPWriter {
 	{
 		if(1 === $min && 1 === $max) return $code;
         
-        $counterName = '$count' . $id;
+		$counterName = '$count' . $id;
 		return PHPBuilder::build()->l(
-            $counterName . ' = 0;'
+			$counterName . ' = 0;'
 		)->b(
 			'while (' . $counterName . ' < '.$max.')',
 			$this->save($id),
@@ -164,7 +164,7 @@ abstract class Token extends PHPWriter {
 				'MATCH' => \null,
 				'FAIL' => $this->restore($id, \true)->l('break;')
 			)),
-            $counterName . '++;'
+			$counterName . '++;'
 		)->b(
 			'if (' . $counterName . ' >= '.$min.')',
 			'MATCH'

--- a/lib/hafriedlander/Peg/Compiler/Token.php
+++ b/lib/hafriedlander/Peg/Compiler/Token.php
@@ -130,8 +130,9 @@ abstract class Token extends PHPWriter {
 
 	protected function n_or_more($code, $id, $n)
 	{
+		$counterName = '$count' . $id;
 		return PHPBuilder::build()->l(
-			'$count = 0;'
+            $counterName . ' = 0;'
 		)->b(
 			'while (\true)',
 			$this->save($id),
@@ -139,9 +140,9 @@ abstract class Token extends PHPWriter {
 				'MATCH' => \null,
 				'FAIL' => $this->restore($id, \true)->l('break;')
 			)),
-			'$count++;'
+            $counterName . '++;'
 		)->b(
-			'if ($count >= '.$n.')',
+			'if (' . $counterName . ' >= '.$n.')',
 			'MATCH'
 		)->b(
 			'else',
@@ -152,19 +153,20 @@ abstract class Token extends PHPWriter {
 	protected function n_to_x($code, $id, $min, $max)
 	{
 		if(1 === $min && 1 === $max) return $code;
-
+        
+        $counterName = '$count' . $id;
 		return PHPBuilder::build()->l(
-			'$count = 0;'
+            $counterName . ' = 0;'
 		)->b(
-			'while ($count < '.$max.')',
+			'while (' . $counterName . ' < '.$max.')',
 			$this->save($id),
 			$code->replace(array(
 				'MATCH' => \null,
 				'FAIL' => $this->restore($id, \true)->l('break;')
 			)),
-			'$count++;'
+            $counterName . '++;'
 		)->b(
-			'if ($count >= '.$min.')',
+			'if (' . $counterName . ' >= '.$min.')',
 			'MATCH'
 		)->b(
 			'else',


### PR DESCRIPTION
If we have rule with nested quantifiers, like example: ("a"+ "bc")+, outer quantifier (one or more) works not correct, because both quantifiers use  variables with same name - $count.